### PR TITLE
use decodedName of @main methods

### DIFF
--- a/mainargs/src/Macros.scala
+++ b/mainargs/src/Macros.scala
@@ -27,7 +27,7 @@ class Macros(val c: Context) {
     val companionObj = weakTypeOf[T].typeSymbol.companion
     val constructor = cls.primaryConstructor.asMethod
     val route = extractMethod(
-      "apply",
+      TermName("apply"),
       constructor.paramLists.flatten,
       constructor.pos,
       cls.annotations.find(_.tpe =:= typeOf[main]),
@@ -76,7 +76,7 @@ class Macros(val c: Context) {
     (vararg, unwrappedType)
   }
 
-  def extractMethod(methodName: String,
+  def extractMethod(methodName: TermName,
                     flattenedArgLists: Seq[Symbol],
                     methodPos: Position,
                     mainAnnotation: Option[Annotation],
@@ -144,11 +144,11 @@ class Macros(val c: Context) {
 
     val res = q"""{
     _root_.mainargs.MainData.create[$returnType, $curCls](
-      $methodName,
+      ${methodName.decodedName.toString},
       $mainInstance,
       Seq(..$argSigs),
       ($baseArgSym: $curCls, $argListSymbol: _root_.scala.Seq[_root_.scala.Any]) => {
-        $baseArgSym.${TermName(methodName)}(..$argNameCasts)
+        $baseArgSym.${methodName}(..$argNameCasts)
       }
     )
     }"""
@@ -163,7 +163,7 @@ class Macros(val c: Context) {
     for(t <- getValsOrMeths(curCls) if pred(t))
     yield {
       extractMethod(
-        t.name.toString,
+        t.name,
         t.paramss.flatten,
         t.pos,
         t.annotations.find(_.tpe =:= typeOf[main]),


### PR DESCRIPTION
to support non-alphanumeric method names, for example
```scala
@main def `opt-show-18+`(): Unit = {}
```

fixes #5 