### PR TITLE
Allow special characters in main method names and argument names

### DIFF
--- a/mainargs/src/Macros.scala
+++ b/mainargs/src/Macros.scala
@@ -28,6 +28,7 @@ class Macros(val c: Context) {
     val constructor = cls.primaryConstructor.asMethod
     val route = extractMethod(
       "apply",
+      "apply",
       constructor.paramLists.flatten,
       constructor.pos,
       cls.annotations.find(_.tpe =:= typeOf[main]),
@@ -77,6 +78,7 @@ class Macros(val c: Context) {
   }
 
   def extractMethod(methodName: String,
+                    decodedMethodName: String,
                     flattenedArgLists: Seq[Symbol],
                     methodPos: Position,
                     mainAnnotation: Option[Annotation],
@@ -114,12 +116,12 @@ class Macros(val c: Context) {
       }
       val argSig = if (vararg) q"""
         _root_.mainargs.ArgSig.createVararg[$varargUnwrappedType, $curCls](
-          ${arg.name.toString},
+          ${arg.name.decoded},
           $instantiateArg,
         ).widen[_root_.scala.Any]
       """ else q"""
         _root_.mainargs.ArgSig.create[$varargUnwrappedType, $curCls](
-          ${arg.name.toString},
+          ${arg.name.decoded},
           $instantiateArg,
           $defaultOpt
         ).widen[_root_.scala.Any]
@@ -144,7 +146,7 @@ class Macros(val c: Context) {
 
     val res = q"""{
     _root_.mainargs.MainData.create[$returnType, $curCls](
-      $methodName,
+      $decodedMethodName,
       $mainInstance,
       _root_.scala.Seq(..$argSigs),
       ($baseArgSym: $curCls, $argListSymbol: _root_.scala.Seq[_root_.scala.Any]) => {
@@ -164,6 +166,7 @@ class Macros(val c: Context) {
     yield {
       extractMethod(
         t.name.toString,
+        t.name.decoded,
         t.paramss.flatten,
         t.pos,
         t.annotations.find(_.tpe =:= typeOf[main]),

--- a/mainargs/src/Macros.scala
+++ b/mainargs/src/Macros.scala
@@ -27,8 +27,7 @@ class Macros(val c: Context) {
     val companionObj = weakTypeOf[T].typeSymbol.companion
     val constructor = cls.primaryConstructor.asMethod
     val route = extractMethod(
-      "apply",
-      "apply",
+      TermName("apply"),
       constructor.paramLists.flatten,
       constructor.pos,
       cls.annotations.find(_.tpe =:= typeOf[main]),
@@ -77,8 +76,7 @@ class Macros(val c: Context) {
     (vararg, unwrappedType)
   }
 
-  def extractMethod(methodName: String,
-                    decodedMethodName: String,
+  def extractMethod(methodName: TermName,
                     flattenedArgLists: Seq[Symbol],
                     methodPos: Position,
                     mainAnnotation: Option[Annotation],
@@ -146,11 +144,11 @@ class Macros(val c: Context) {
 
     val res = q"""{
     _root_.mainargs.MainData.create[$returnType, $curCls](
-      $decodedMethodName,
+      ${methodName.decoded},
       $mainInstance,
       _root_.scala.Seq(..$argSigs),
       ($baseArgSym: $curCls, $argListSymbol: _root_.scala.Seq[_root_.scala.Any]) => {
-        $baseArgSym.${TermName(methodName)}(..$argNameCasts)
+        $baseArgSym.$methodName(..$argNameCasts)
       }
     )
     }"""
@@ -165,8 +163,7 @@ class Macros(val c: Context) {
     for(t <- getValsOrMeths(curCls) if pred(t))
     yield {
       extractMethod(
-        t.name.toString,
-        t.name.decoded,
+        t.name,
         t.paramss.flatten,
         t.pos,
         t.annotations.find(_.tpe =:= typeOf[main]),

--- a/mainargs/test/src/DashedArgumentName.scala
+++ b/mainargs/test/src/DashedArgumentName.scala
@@ -1,0 +1,29 @@
+package mainargs
+import utest._
+
+
+object DashedArgumentName extends TestSuite{
+
+  object Base{
+    @main
+    def `opt-for-18+name`(`opt-for-18+arg`: Boolean) = `opt-for-18+arg`
+    @main
+    def `opt-for-29+name`(`opt-for-29+arg`: Boolean) = `opt-for-29+arg`
+  }
+  val check = new Checker(ParserForMethods(Base), allowPositional = true)
+
+  val tests = Tests {
+    test - check(
+      List("opt-for-18+name", "--opt-for-18+arg", "true"), Result.Success(true)
+    )
+    test - check(
+      List("opt-for-18+name", "--opt-for-18+arg", "false"), Result.Success(false)
+    )
+    test - check(
+      List("opt-for-29+name", "--opt-for-29+arg", "true"), Result.Success(true)
+    )
+    test - check(
+      List("opt-for-29+name", "--opt-for-29+arg", "false"), Result.Success(false)
+    )
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mainargs/issues/8

We need to use `.decoded` to ensure we get the non-mangled version. Added a unit test to verify the fix

Review by @lolgab 