### PR TITLE
Test that crashes compiler with an unexpected type representation

### DIFF
--- a/mainargs/test/src/ClassTests.scala
+++ b/mainargs/test/src/ClassTests.scala
@@ -17,6 +17,13 @@ object ClassTests extends TestSuite{
   implicit val barParser = ParserForClass[Bar]
   implicit val quxParser = ParserForClass[Qux]
 
+  @main
+  case class Boo(x: Int = 3)
+
+  object Boo {
+    implicit val parser = ParserForClass[Boo]
+  }
+
   object Main{
     @main
     def run(bar: Bar,
@@ -87,6 +94,10 @@ object ClassTests extends TestSuite{
           )
           ) =>
         }
+      }
+      test("implicitInCompanionObject") {
+        Boo.parser.constructOrThrow(Seq("-x", "3")) ==>
+          Boo(3)
       }
     }
 


### PR DESCRIPTION
hi there!
i ran into situation that crashed scala compiler so i recreated it in a unit test. i did not fix the issue.

```
$ ./mill -i mainargs.jvm[2.12.13].test
[55/62] mainargs.jvm[2.12.13].test.compile 
...
[warn] an unexpected type representation reached the compiler backend while compiling ClassTests.scala: <error>. If possible, please file a bug on https://github.com/scala/bug/issues.
[error] Error while emitting ClassTests.scala
[error] <error> (of class scala.reflect.internal.Types$ErrorType$)
[error] Error while emitting ClassTests.scala
[error] assertion failed: ClassBType.info not yet assigned: Lmainargs/ClassTests$Boo$;
[warn] two warnings found
[error] two errors found
1 targets failed
mainargs.jvm[2.12.13].test.compile Compilation failed
```