### PR TITLE
allow option to wrap something thats repeatable and keep it repeatable

### DIFF
--- a/mainargs/test/src/OptionSeqTests.scala
+++ b/mainargs/test/src/OptionSeqTests.scala
@@ -18,6 +18,9 @@ object OptionSeqTests extends TestSuite{
 
     @main
     def runInt(int: Int) = int
+
+    @main
+    def runOptionSeq(os: Option[Seq[Int]]) = os
   }
 
   val tests = Tests {
@@ -42,6 +45,24 @@ object OptionSeqTests extends TestSuite{
           Seq(123)
       }
     }
+
+    test("option seq") {
+      test {
+        ParserForMethods(Main).runOrThrow(Array("runOptionSeq", "--os", "123")) ==>
+          Some(Seq(123))
+      }
+
+      test {
+        ParserForMethods(Main).runOrThrow(Array("runOptionSeq", "--os", "123", "--os", "456")) ==>
+          Some(Seq(123, 456))
+      }
+
+      test {
+        ParserForMethods(Main).runOrThrow(Array("runOptionSeq")) ==>
+          None
+      }
+    }
+
     test("vec"){
       ParserForMethods(Main).runOrThrow(Array("runVec", "--seq", "123", "--seq", "456")) ==>
         Vector(123, 456)


### PR DESCRIPTION
we have an internal class T that acts like a lists but is not allowed to be empty, for which we implemented a TokensReader that is repeatable and does not allow empty.
to be able to support `Option[T]` as an argument `OptionRead[T]` needs to respect `alwaysRepeatable` for `TokensReader[T]`. 