### PR TITLE
Support sorting of arguments in help text

### DIFF
--- a/mainargs/src/Parser.scala
+++ b/mainargs/src/Parser.scala
@@ -12,7 +12,7 @@ class ParserForMethods[B](val mains: MethodMains[B]) {
       docsOnNewLine: Boolean = false,
       customNames: Map[String, String] = Map(),
       customDocs: Map[String, String] = Map(),
-      sorted: Boolean = false
+      sorted: Boolean = true
   ): String = {
     Renderer.formatMainMethods(
       mains.value,
@@ -30,7 +30,7 @@ class ParserForMethods[B](val mains: MethodMains[B]) {
       docsOnNewLine: Boolean,
       customNames: Map[String, String],
       customDocs: Map[String, String]
-  ): String = helpText(totalWidth, docsOnNewLine, customNames, customDocs, sorted = false)
+  ): String = helpText(totalWidth, docsOnNewLine, customNames, customDocs, sorted = true)
 
   def runOrExit(
       args: Seq[String],
@@ -181,7 +181,7 @@ class ParserForClass[T](val mains: ClassMains[T]) extends SubParser[T] {
       docsOnNewLine: Boolean = false,
       customName: String = null,
       customDoc: String = null,
-      sorted: Boolean = false
+      sorted: Boolean = true
   ): String = {
     Renderer.formatMainMethodSignature(
       mains.main,
@@ -201,7 +201,7 @@ class ParserForClass[T](val mains: ClassMains[T]) extends SubParser[T] {
       docsOnNewLine: Boolean,
       customName: String,
       customDoc: String
-  ): String = helpText(totalWidth, docsOnNewLine, customName, customDoc, sorted = false)
+  ): String = helpText(totalWidth, docsOnNewLine, customName, customDoc, sorted = true)
 
   def constructOrExit(
       args: Seq[String],
@@ -270,7 +270,7 @@ class ParserForClass[T](val mains: ClassMains[T]) extends SubParser[T] {
       autoPrintHelpAndExit: Option[(Int, PrintStream)] = Some((0, System.out)),
       customName: String = null,
       customDoc: String = null,
-      sorted: Boolean = false
+      sorted: Boolean = true
   ): Either[String, T] = {
     if (autoPrintHelpAndExit.nonEmpty && args.take(1) == Seq("--help")) {
       val (exitCode, outputStream) = autoPrintHelpAndExit.get
@@ -315,7 +315,7 @@ class ParserForClass[T](val mains: ClassMains[T]) extends SubParser[T] {
     autoPrintHelpAndExit,
     customName,
     customDoc,
-    sorted = false
+    sorted = true
   )
 
   def constructRaw(

--- a/mainargs/src/Parser.scala
+++ b/mainargs/src/Parser.scala
@@ -24,7 +24,7 @@ class ParserForMethods[B](val mains: MethodMains[B]) {
     )
   }
 
-  /** binary compatibility shim. */
+  @deprecated("Binary compatibility shim, use other overload instead", "mainargs after 0.3.0")
   private[mainargs] def helpText(
       totalWidth: Int,
       docsOnNewLine: Boolean,
@@ -127,7 +127,7 @@ class ParserForMethods[B](val mains: MethodMains[B]) {
     }
   }
 
-  /** binary compatibility shim. */
+  @deprecated("Binary compatibility shim, use other overload instead", "mainargs after 0.3.0")
   private[mainargs] def runEither(
       args: Seq[String],
       allowPositional: Boolean,
@@ -195,7 +195,7 @@ class ParserForClass[T](val mains: ClassMains[T]) extends SubParser[T] {
     )
   }
 
-  /** binary compatibility shim. */
+  @deprecated("Binary compatibility shim, use other overload instead", "mainargs after 0.3.0")
   private[mainargs] def helpText(
       totalWidth: Int,
       docsOnNewLine: Boolean,

--- a/mainargs/src/Parser.scala
+++ b/mainargs/src/Parser.scala
@@ -24,6 +24,14 @@ class ParserForMethods[B](val mains: MethodMains[B]) {
     )
   }
 
+  /** binary compatibility shim. */
+  private[mainargs] def helpText(
+      totalWidth: Int,
+      docsOnNewLine: Boolean,
+      customNames: Map[String, String],
+      customDocs: Map[String, String]
+  ): String = helpText(totalWidth, docsOnNewLine, customNames, customDocs, sorted = false)
+
   def runOrExit(
       args: Seq[String],
       allowPositional: Boolean = false,
@@ -116,9 +124,32 @@ class ParserForMethods[B](val mains: MethodMains[B]) {
               )
             )
         }
-
     }
   }
+
+  /** binary compatibility shim. */
+  private[mainargs] def runEither(
+      args: Seq[String],
+      allowPositional: Boolean,
+      allowRepeats: Boolean,
+      totalWidth: Int,
+      printHelpOnExit: Boolean,
+      docsOnNewLine: Boolean,
+      autoPrintHelpAndExit: Option[(Int, PrintStream)],
+      customNames: Map[String, String],
+      customDocs: Map[String, String]
+  ): Either[String, Any] = runEither(
+    args,
+    allowPositional,
+    allowRepeats,
+    totalWidth,
+    printHelpOnExit,
+    docsOnNewLine,
+    autoPrintHelpAndExit,
+    customNames,
+    customDocs,
+    sorted = false
+  )
 
   def runRaw(
       args: Seq[String],
@@ -151,7 +182,7 @@ class ParserForClass[T](val mains: ClassMains[T]) extends SubParser[T] {
       customName: String = null,
       customDoc: String = null,
       sorted: Boolean = false
-  ) = {
+  ): String = {
     Renderer.formatMainMethodSignature(
       mains.main,
       0,
@@ -163,6 +194,14 @@ class ParserForClass[T](val mains: ClassMains[T]) extends SubParser[T] {
       sorted
     )
   }
+
+  /** binary compatibility shim. */
+  private[mainargs] def helpText(
+      totalWidth: Int,
+      docsOnNewLine: Boolean,
+      customName: String,
+      customDoc: String
+  ): String = helpText(totalWidth, docsOnNewLine, customName, customDoc, sorted = false)
 
   def constructOrExit(
       args: Seq[String],
@@ -253,8 +292,32 @@ class ParserForClass[T](val mains: ClassMains[T]) extends SubParser[T] {
           )
         )
     }
-
   }
+
+  /** binary compatibility shim. */
+  private[mainargs] def constructEither(
+      args: Seq[String],
+      allowPositional: Boolean,
+      allowRepeats: Boolean,
+      totalWidth: Int,
+      printHelpOnExit: Boolean,
+      docsOnNewLine: Boolean,
+      autoPrintHelpAndExit: Option[(Int, PrintStream)],
+      customName: String,
+      customDoc: String
+  ): Either[String, T] = constructEither(
+    args,
+    allowPositional,
+    allowRepeats,
+    totalWidth,
+    printHelpOnExit,
+    docsOnNewLine,
+    autoPrintHelpAndExit,
+    customName,
+    customDoc,
+    sorted = false
+  )
+
   def constructRaw(
       args: Seq[String],
       allowPositional: Boolean = false,

--- a/mainargs/src/Parser.scala
+++ b/mainargs/src/Parser.scala
@@ -11,16 +11,19 @@ class ParserForMethods[B](val mains: MethodMains[B]) {
       totalWidth: Int = 100,
       docsOnNewLine: Boolean = false,
       customNames: Map[String, String] = Map(),
-      customDocs: Map[String, String] = Map()
-  ) = {
+      customDocs: Map[String, String] = Map(),
+      sorted: Boolean = false
+  ): String = {
     Renderer.formatMainMethods(
       mains.value,
       totalWidth,
       docsOnNewLine,
       customNames,
-      customDocs
+      customDocs,
+      sorted
     )
   }
+
   def runOrExit(
       args: Seq[String],
       allowPositional: Boolean = false,
@@ -50,6 +53,7 @@ class ParserForMethods[B](val mains: MethodMains[B]) {
       case Right(v) => v
     }
   }
+
   def runOrThrow(
       args: Seq[String],
       allowPositional: Boolean = false,
@@ -76,6 +80,7 @@ class ParserForMethods[B](val mains: MethodMains[B]) {
       case Right(v) => v
     }
   }
+
   def runEither(
       args: Seq[String],
       allowPositional: Boolean = false,
@@ -85,11 +90,12 @@ class ParserForMethods[B](val mains: MethodMains[B]) {
       docsOnNewLine: Boolean = false,
       autoPrintHelpAndExit: Option[(Int, PrintStream)] = Some((0, System.out)),
       customNames: Map[String, String] = Map(),
-      customDocs: Map[String, String] = Map()
+      customDocs: Map[String, String] = Map(),
+      sorted: Boolean = false
   ): Either[String, Any] = {
     if (autoPrintHelpAndExit.nonEmpty && args.take(1) == Seq("--help")) {
       val (exitCode, outputStream) = autoPrintHelpAndExit.get
-      outputStream.println(helpText(totalWidth, docsOnNewLine, customNames, customDocs))
+      outputStream.println(helpText(totalWidth, docsOnNewLine, customNames, customDocs, sorted))
       Compat.exit(exitCode)
     } else runRaw0(args, allowPositional, allowRepeats) match {
       case Left(err) => Left(Renderer.renderEarlyError(err))
@@ -105,13 +111,15 @@ class ParserForMethods[B](val mains: MethodMains[B]) {
                 printHelpOnExit,
                 docsOnNewLine,
                 customNames.get(main.name),
-                customDocs.get(main.name)
+                customDocs.get(main.name),
+                sorted
               )
             )
         }
 
     }
   }
+
   def runRaw(
       args: Seq[String],
       allowPositional: Boolean = false,
@@ -141,7 +149,8 @@ class ParserForClass[T](val mains: ClassMains[T]) extends SubParser[T] {
       totalWidth: Int = 100,
       docsOnNewLine: Boolean = false,
       customName: String = null,
-      customDoc: String = null
+      customDoc: String = null,
+      sorted: Boolean = false
   ) = {
     Renderer.formatMainMethodSignature(
       mains.main,
@@ -150,9 +159,11 @@ class ParserForClass[T](val mains: ClassMains[T]) extends SubParser[T] {
       Renderer.getLeftColWidth(mains.main.argSigs),
       docsOnNewLine,
       Option(customName),
-      Option(customDoc)
+      Option(customDoc),
+      sorted
     )
   }
+
   def constructOrExit(
       args: Seq[String],
       allowPositional: Boolean = false,
@@ -182,6 +193,7 @@ class ParserForClass[T](val mains: ClassMains[T]) extends SubParser[T] {
       case Right(v) => v
     }
   }
+
   def constructOrThrow(
       args: Seq[String],
       allowPositional: Boolean = false,
@@ -208,6 +220,7 @@ class ParserForClass[T](val mains: ClassMains[T]) extends SubParser[T] {
       case Right(v) => v
     }
   }
+
   def constructEither(
       args: Seq[String],
       allowPositional: Boolean = false,
@@ -217,11 +230,12 @@ class ParserForClass[T](val mains: ClassMains[T]) extends SubParser[T] {
       docsOnNewLine: Boolean = false,
       autoPrintHelpAndExit: Option[(Int, PrintStream)] = Some((0, System.out)),
       customName: String = null,
-      customDoc: String = null
+      customDoc: String = null,
+      sorted: Boolean = false
   ): Either[String, T] = {
     if (autoPrintHelpAndExit.nonEmpty && args.take(1) == Seq("--help")) {
       val (exitCode, outputStream) = autoPrintHelpAndExit.get
-      outputStream.println(helpText(totalWidth, docsOnNewLine, customName, customDoc))
+      outputStream.println(helpText(totalWidth, docsOnNewLine, customName, customDoc, sorted))
       Compat.exit(exitCode)
     } else constructRaw(args, allowPositional, allowRepeats) match {
       case Result.Success(v) => Right(v)
@@ -234,7 +248,8 @@ class ParserForClass[T](val mains: ClassMains[T]) extends SubParser[T] {
             printHelpOnExit,
             docsOnNewLine,
             Option(customName),
-            Option(customDoc)
+            Option(customDoc),
+            sorted
           )
         )
     }

--- a/mainargs/src/Renderer.scala
+++ b/mainargs/src/Renderer.scala
@@ -41,14 +41,14 @@ object Renderer {
       a.name.orElse(Some(""))
   }
 
-  object ArgOrd extends math.Ordering[ArgSig.Terminal[_,_]] {
+  object ArgOrd extends math.Ordering[ArgSig.Terminal[_, _]] {
     override def compare(x: ArgSig.Terminal[_, _], y: ArgSig.Terminal[_, _]): Int =
-      (sortableName(x),sortableName(y)) match {
-      case (None, None) => 0 // don't sort leftovers
-      case (None, Some(_)) => 1 // keep left overs at the end
-      case (Some(_), None) => -1 // keep left overs at the end
-      case (Some(l), Some(r)) => l.compare(r)
-    }
+      (sortableName(x), sortableName(y)) match {
+        case (None, None) => 0 // don't sort leftovers
+        case (None, Some(_)) => 1 // keep left overs at the end
+        case (Some(_), None) => -1 // keep left overs at the end
+        case (Some(l), Some(r)) => l.compare(r)
+      }
   }
 
   def renderArg(
@@ -107,6 +107,22 @@ object Renderer {
     }
   }
 
+  @deprecated("Use other overload instead", "mainargs after 0.3.0")
+  def formatMainMethods(
+      mainMethods: Seq[MainData[_, _]],
+      totalWidth: Int,
+      docsOnNewLine: Boolean,
+      customNames: Map[String, String],
+      customDocs: Map[String, String]
+  ): String = formatMainMethods(
+    mainMethods,
+    totalWidth,
+    docsOnNewLine,
+    customNames,
+    customDocs,
+    sorted = false
+  )
+
   def formatMainMethodSignature(
       main: MainData[_, _],
       leftIndent: Int,
@@ -116,12 +132,12 @@ object Renderer {
       customName: Option[String],
       customDoc: Option[String],
       sorted: Boolean
-  ) = {
+  ): String = {
 
     val argLeftCol = if (docsOnNewLine) leftIndent + 8 else leftColWidth + leftIndent + 2 + 2
 
     val sortedArgs =
-      if(sorted) main.argSigs.sorted(ArgOrd)
+      if (sorted) main.argSigs.sorted(ArgOrd)
       else main.argSigs
 
     val args = sortedArgs.map(renderArg(_, argLeftCol, totalWidth))
@@ -147,6 +163,26 @@ object Renderer {
     s"""$leftIndentStr${customName.getOrElse(main.name)}$mainDocSuffix
        |${argStrings.map(_ + newLine).mkString}""".stripMargin
   }
+
+  @deprecated("Use other overload instead", "mainargs after 0.3.0")
+  def formatMainMethodSignature(
+      main: MainData[_, _],
+      leftIndent: Int,
+      totalWidth: Int,
+      leftColWidth: Int,
+      docsOnNewLine: Boolean,
+      customName: Option[String],
+      customDoc: Option[String]
+  ): String = formatMainMethodSignature(
+    main,
+    leftIndent,
+    totalWidth,
+    leftColWidth,
+    docsOnNewLine,
+    customName,
+    customDoc,
+    sorted = false
+  )
 
   def softWrap(s: String, leftOffset: Int, maxWidth: Int) = {
     if (s.isEmpty) s
@@ -185,6 +221,7 @@ object Renderer {
       "To select a subcommand to run, you don't need --s." + Renderer.newLine +
         s"Did you mean `${token.drop(2)}` instead of `$token`?"
   }
+
   def renderResult(
       main: MainData[_, _],
       result: Result.Failure,
@@ -284,4 +321,24 @@ object Renderer {
         )
     }
   }
+
+  @deprecated("Use other overload instead", "mainargs after 0.3.0")
+  def renderResult(
+      main: MainData[_, _],
+      result: Result.Failure,
+      totalWidth: Int,
+      printHelpOnError: Boolean,
+      docsOnNewLine: Boolean,
+      customName: Option[String],
+      customDoc: Option[String]
+  ): String = renderResult(
+    main,
+    result,
+    totalWidth,
+    printHelpOnError,
+    docsOnNewLine,
+    customName,
+    customDoc,
+    sorted = false
+  )
 }

--- a/mainargs/src/Renderer.scala
+++ b/mainargs/src/Renderer.scala
@@ -120,7 +120,7 @@ object Renderer {
     docsOnNewLine,
     customNames,
     customDocs,
-    sorted = false
+    sorted = true
   )
 
   def formatMainMethodSignature(
@@ -181,7 +181,7 @@ object Renderer {
     docsOnNewLine,
     customName,
     customDoc,
-    sorted = false
+    sorted = true
   )
 
   def softWrap(s: String, leftOffset: Int, maxWidth: Int) = {
@@ -339,6 +339,6 @@ object Renderer {
     docsOnNewLine,
     customName,
     customDoc,
-    sorted = false
+    sorted = true
   )
 }

--- a/mainargs/test/src-jvm-2/AmmoniteTests.scala
+++ b/mainargs/test/src-jvm-2/AmmoniteTests.scala
@@ -126,10 +126,10 @@ object AmmoniteTests extends TestSuite {
   val parser = ParserForClass[AmmoniteConfig]
   val tests = Tests {
 
-    test("formatMainMethods") {
+    test("formatMainMethods.unsorted") {
       val customName = s"Ammonite REPL & Script-Runner"
       val customDoc = "usage: amm [ammonite-options] [script-file [script-options]]"
-      val rendered = parser.helpText(customName = customName, customDoc = customDoc).trim
+      val rendered = parser.helpText(customName = customName, customDoc = customDoc, sorted = false).trim
       val expected =
         """Ammonite REPL & Script-Runner
           |usage: amm [ammonite-options] [script-file [script-options]]

--- a/mainargs/test/src-jvm-2/AmmoniteTests.scala
+++ b/mainargs/test/src-jvm-2/AmmoniteTests.scala
@@ -13,109 +13,120 @@ object AmmoniteDefaults {
   def ammoniteHome = os.Path(System.getProperty("user.home")) / ".ammonite"
 }
 @main
-case class AmmoniteConfig(core: AmmoniteConfig.Core,
-                          predef: AmmoniteConfig.Predef,
-                          repl: AmmoniteConfig.Repl,
-                          rest: Leftover[String])
+case class AmmoniteConfig(
+    core: AmmoniteConfig.Core,
+    predef: AmmoniteConfig.Predef,
+    repl: AmmoniteConfig.Repl,
+    rest: Leftover[String]
+)
 
-object AmmoniteConfig{
-  implicit object PathRead extends TokensReader[os.Path]("path", strs => Right(os.Path(strs.head, os.pwd)))
+object AmmoniteConfig {
+  implicit object PathRead
+      extends TokensReader[os.Path]("path", strs => Right(os.Path(strs.head, os.pwd)))
   @main
   case class Core(
-    @arg(
-      name = "no-default-predef",
-      doc = "Disable the default predef and run Ammonite with the minimal predef possible")
-    noDefaultPredef: Flag,
-    @arg(
-      short = 's',
-      doc =
-        "Make ivy logs go silent instead of printing though failures will " +
-        "still throw exception")
-    silent: Flag,
-
-    @arg(
-      short = 'w',
-      doc = "Watch and re-run your scripts when they change")
-    watch: Flag,
-    @arg(doc = "Run a BSP server against the passed scripts")
-    bsp: Flag,
-    @arg(
-      short = 'c',
-      doc = "Pass in code to be run immediately in the REPL")
-    code: Option[String] = None,
-    @arg(
-      short = 'h',
-      doc = "The home directory of the REPL; where it looks for config and caches")
-    home: os.Path = AmmoniteDefaults.ammoniteHome,
-    @arg(
-      name = "predef",
-      short = 'p',
-      doc =
-        "Lets you load your predef from a custom location, rather than the " +
-        "default location in your Ammonite home")
-    predefFile: Option[os.Path] = None,
-    @arg(
-      doc =
-        "Enable or disable colored output; by default colors are enabled " +
-          "in both REPL and scripts if the console is interactive, and disabled " +
-          "otherwise")
-    color: Option[Boolean] = None,
-    @arg(
-      doc =
-        "Hide parts of the core of Ammonite and some of its dependencies. By default, " +
-        "the core of  Ammonite and all of its dependencies can be seen by users from the " +
-        "Ammonite session. This option mitigates that via class loader isolation.")
-    thin: Flag,
-    @arg(doc = "Print this message")
-    help: Flag
+      @arg(
+        name = "no-default-predef",
+        doc = "Disable the default predef and run Ammonite with the minimal predef possible"
+      )
+      noDefaultPredef: Flag,
+      @arg(
+        short = 's',
+        doc =
+          "Make ivy logs go silent instead of printing though failures will " +
+            "still throw exception"
+      )
+      silent: Flag,
+      @arg(
+        short = 'w',
+        doc = "Watch and re-run your scripts when they change"
+      )
+      watch: Flag,
+      @arg(doc = "Run a BSP server against the passed scripts")
+      bsp: Flag,
+      @arg(
+        short = 'c',
+        doc = "Pass in code to be run immediately in the REPL"
+      )
+      code: Option[String] = None,
+      @arg(
+        short = 'h',
+        doc = "The home directory of the REPL; where it looks for config and caches"
+      )
+      home: os.Path = AmmoniteDefaults.ammoniteHome,
+      @arg(
+        name = "predef",
+        short = 'p',
+        doc =
+          "Lets you load your predef from a custom location, rather than the " +
+            "default location in your Ammonite home"
+      )
+      predefFile: Option[os.Path] = None,
+      @arg(
+        doc =
+          "Enable or disable colored output; by default colors are enabled " +
+            "in both REPL and scripts if the console is interactive, and disabled " +
+            "otherwise"
+      )
+      color: Option[Boolean] = None,
+      @arg(
+        doc =
+          "Hide parts of the core of Ammonite and some of its dependencies. By default, " +
+            "the core of  Ammonite and all of its dependencies can be seen by users from the " +
+            "Ammonite session. This option mitigates that via class loader isolation."
+      )
+      thin: Flag,
+      @arg(doc = "Print this message")
+      help: Flag
   )
   implicit val coreParser = ParserForClass[Core]
 
   @main
   case class Predef(
-    @arg(
-      name = "predef-code",
-      doc = "Any commands you want to execute at the start of the REPL session")
-    predefCode: String = "",
-
-    @arg(
-      name = "no-home-predef",
-      doc =
-        "Disables the default behavior of loading predef files from your "+
-        "~/.ammonite/predef.sc, predefScript.sc, or predefShared.sc. You can "+
-        "choose an additional predef to use using `--predef")
-    noHomePredef: Flag
+      @arg(
+        name = "predef-code",
+        doc = "Any commands you want to execute at the start of the REPL session"
+      )
+      predefCode: String = "",
+      @arg(
+        name = "no-home-predef",
+        doc =
+          "Disables the default behavior of loading predef files from your " +
+            "~/.ammonite/predef.sc, predefScript.sc, or predefShared.sc. You can " +
+            "choose an additional predef to use using `--predef"
+      )
+      noHomePredef: Flag
   )
   implicit val predefParser = ParserForClass[Predef]
 
   @main
   case class Repl(
-  @arg(
-      short = 'b',
-      doc = "Customize the welcome banner that gets shown when Ammonite starts")
-    banner: String = AmmoniteDefaults.welcomeBanner,
-    @arg(
-      name = "no-remote-logging",
-      doc =
-      "(deprecated) Disable remote logging of the number of times a REPL starts and runs commands")
-    noRemoteLogging: Flag,
-    @arg(
-      doc =
-        "Wrap user code in classes rather than singletons, typically for Java serialization "+
-        "friendliness.")
-    classBased: Flag
+      @arg(
+        short = 'b',
+        doc = "Customize the welcome banner that gets shown when Ammonite starts"
+      )
+      banner: String = AmmoniteDefaults.welcomeBanner,
+      @arg(
+        name = "no-remote-logging",
+        doc =
+          "(deprecated) Disable remote logging of the number of times a REPL starts and runs commands"
+      )
+      noRemoteLogging: Flag,
+      @arg(
+        doc =
+          "Wrap user code in classes rather than singletons, typically for Java serialization " +
+            "friendliness."
+      )
+      classBased: Flag
   )
   implicit val replParser = ParserForClass[Repl]
 }
 
-
-object AmmoniteTests extends TestSuite{
+object AmmoniteTests extends TestSuite {
   val parser = ParserForClass[AmmoniteConfig]
   val tests = Tests {
 
-
-
-    test("formatMainMethods"){
+    test("formatMainMethods") {
       val customName = s"Ammonite REPL & Script-Runner"
       val customDoc = "usage: amm [ammonite-options] [script-file [script-options]]"
       val rendered = parser.helpText(customName = customName, customDoc = customDoc).trim
@@ -152,7 +163,47 @@ object AmmoniteTests extends TestSuite{
       assert(rendered == expected)
 
     }
-    test("parseInvoke"){
+
+    test("formatMainMethods.sorted") {
+      val customName = s"Ammonite REPL & Script-Runner"
+      val customDoc = "usage: amm [ammonite-options] [script-file [script-options]]"
+      val rendered =
+        parser.helpText(customName = customName, customDoc = customDoc, sorted = true).trim
+      val expected =
+        """Ammonite REPL & Script-Runner
+          |usage: amm [ammonite-options] [script-file [script-options]]
+          |  -b --banner <str>    Customize the welcome banner that gets shown when Ammonite starts
+          |  --bsp                Run a BSP server against the passed scripts
+          |  -c --code <str>      Pass in code to be run immediately in the REPL
+          |  --classBased         Wrap user code in classes rather than singletons, typically for Java
+          |                       serialization friendliness.
+          |  --color <bool>       Enable or disable colored output; by default colors are enabled in both REPL
+          |                       and scripts if the console is interactive, and disabled otherwise
+          |  -h --home <path>     The home directory of the REPL; where it looks for config and caches
+          |  --help               Print this message
+          |  --no-default-predef  Disable the default predef and run Ammonite with the minimal predef possible
+          |  --no-home-predef     Disables the default behavior of loading predef files from your
+          |                       ~/.ammonite/predef.sc, predefScript.sc, or predefShared.sc. You can choose an
+          |                       additional predef to use using `--predef
+          |  --no-remote-logging  (deprecated) Disable remote logging of the number of times a REPL starts and
+          |                       runs commands
+          |  -p --predef <path>   Lets you load your predef from a custom location, rather than the default
+          |                       location in your Ammonite home
+          |  --predef-code <str>  Any commands you want to execute at the start of the REPL session
+          |  -s --silent          Make ivy logs go silent instead of printing though failures will still throw
+          |                       exception
+          |  --thin               Hide parts of the core of Ammonite and some of its dependencies. By default,
+          |                       the core of Ammonite and all of its dependencies can be seen by users from
+          |                       the Ammonite session. This option mitigates that via class loader isolation.
+          |  -w --watch           Watch and re-run your scripts when they change
+          |  rest <str>...
+          |""".stripMargin.trim
+
+      assert(rendered == expected)
+
+    }
+
+    test("parseInvoke") {
       parser.constructEither(Array("--code", "println(1)")) ==>
         Right(
           AmmoniteConfig(
@@ -173,4 +224,3 @@ object AmmoniteTests extends TestSuite{
     }
   }
 }
-


### PR DESCRIPTION
Added the option to sort args in the rendered help text.

* Fixes #48 

I also added some shim to keep source- and binary compatibility.

I think most users expect a sorted list of cli option when calling `--help`, so a default of `true` would be the most reasonable. As that is at least a minor change in appearance, I suggest to bump the next release to `0.4`. 

/cc @lihaoyi @lolgab 