### PR TITLE
Fix case class default parameter detection and annotation detection in Scala3

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -55,7 +55,8 @@ trait MainArgsPublishModule
     )
 
   def ivyDeps = Agg(
-    ivy"org.scala-lang.modules::scala-collection-compat::2.8.1"
+    ivy"org.scala-lang.modules::scala-collection-compat::2.8.1",
+    ivy"com.lihaoyi::pprint:0.8.1"
   )
 }
 

--- a/mainargs/src-3/Macros.scala
+++ b/mainargs/src-3/Macros.scala
@@ -12,11 +12,7 @@ object Macros {
       methodSymbol.getAnnotation(mainAnnotation).map(methodSymbol -> _)
     }.sortBy(_._1.pos.map(_.start))
     val mainDatas = Expr.ofList(annotatedMethodsWithMainAnnotations.map { (annotatedMethod, mainAnnotationInstance) =>
-      createMainData[Any, B](
-        annotatedMethod,
-        mainAnnotationInstance,
-        annotatedMethod.paramSymss
-      )
+      createMainData[Any, B](annotatedMethod, mainAnnotationInstance)
     })
 
     '{
@@ -53,6 +49,12 @@ object Macros {
           TypeRepr.of[B].typeSymbol.primaryConstructor.paramSymss
         )
         '{ new ParserForClass[B](${ mainData }, () => ${ Ident(companionModule).asExpr }) }
+  }
+
+  def createMainData[T: Type, B: Type](using Quotes)
+                                      (method: quotes.reflect.Symbol,
+                                       mainAnnotation: quotes.reflect.Term): Expr[MainData[T, B]] = {
+    createMainData[T, B](method, mainAnnotation, method.paramSymss)
   }
 
   def createMainData[T: Type, B: Type](using Quotes)

--- a/mainargs/src-3/Macros.scala
+++ b/mainargs/src-3/Macros.scala
@@ -143,8 +143,8 @@ object Macros {
         val expr = Ref(deff.symbol).asExpr
         defaults += (params(idx.toInt - 1) -> expr)
 
-      // The `apply` method re-uses the default param factory methods from `<init>`,
-      // so make sure to check if those exist too
+      // The `apply` method re-uses the default param factory methods
+      // from `<init>`, so make sure to check if those exist too
       case deff @ DefDef(InitName(idx), _, _, _) if method.name == "apply" =>
         val expr = Ref(deff.symbol).asExpr
         defaults += (params(idx.toInt - 1) -> expr)

--- a/mainargs/test/src/ClassTests.scala
+++ b/mainargs/test/src/ClassTests.scala
@@ -58,121 +58,108 @@ object ClassTests extends TestSuite {
           Bar(Flag(true), Foo(1, 2), "xxx")
       }
       test("missingInner") {
-        // Blocked by https://github.com/lampepfl/dotty/issues/12492
-        TestUtils.scala2Only {
-          barParser.constructRaw(Seq("-w", "-x", "1", "-z", "xxx")) ==>
-            Result.Failure.MismatchedArguments(
-              Seq(
-                ArgSig(
-                  None,
-                  Some('y'),
-                  None,
-                  None,
-                  mainargs.TokensReader.IntRead,
-                  positional = false,
-                  hidden = false
-                )
-              ),
-              List(),
-              List(),
-              None
-            )
-        }
+        barParser.constructRaw(Seq("-w", "-x", "1", "-z", "xxx")) ==>
+          Result.Failure.MismatchedArguments(
+            Seq(
+              ArgSig(
+                None,
+                Some('y'),
+                None,
+                None,
+                mainargs.TokensReader.IntRead,
+                positional = false,
+                hidden = false
+              )
+            ),
+            List(),
+            List(),
+            None
+          )
       }
       test("missingOuter") {
-        // Blocked by https://github.com/lampepfl/dotty/issues/12492
-        TestUtils.scala2Only {
-          barParser.constructRaw(Seq("-w", "-x", "1", "-y", "2")) ==>
-            Result.Failure.MismatchedArguments(
-              Seq(
-                ArgSig(
-                  Some("zzzz"),
-                  Some('z'),
-                  None,
-                  None,
-                  mainargs.TokensReader.StringRead,
-                  positional = false,
-                  hidden = false
-                )
-              ),
-              List(),
-              List(),
-              None
-            )
-        }
+        barParser.constructRaw(Seq("-w", "-x", "1", "-y", "2")) ==>
+          Result.Failure.MismatchedArguments(
+            Seq(
+              ArgSig(
+                Some("zzzz"),
+                Some('z'),
+                None,
+                None,
+                mainargs.TokensReader.StringRead,
+                positional = false,
+                hidden = false
+              )
+            ),
+            List(),
+            List(),
+            None
+          )
       }
 
       test("missingInnerOuter") {
-        // Blocked by https://github.com/lampepfl/dotty/issues/12492
-        TestUtils.scala2Only {
-          barParser.constructRaw(Seq("-w", "-x", "1")) ==>
-            Result.Failure.MismatchedArguments(
-              Seq(
-                ArgSig(
-                  None,
-                  Some('y'),
-                  None,
-                  None,
-                  mainargs.TokensReader.IntRead,
-                  positional = false,
-                  hidden = false
-                ),
-                ArgSig(
-                  Some("zzzz"),
-                  Some('z'),
-                  None,
-                  None,
-                  mainargs.TokensReader.StringRead,
-                  positional = false,
-                  hidden = false
-                )
+        barParser.constructRaw(Seq("-w", "-x", "1")) ==>
+          Result.Failure.MismatchedArguments(
+            Seq(
+              ArgSig(
+                None,
+                Some('y'),
+                None,
+                None,
+                mainargs.TokensReader.IntRead,
+                positional = false,
+                hidden = false
               ),
-              List(),
-              List(),
-              None
-            )
-        }
+              ArgSig(
+                Some("zzzz"),
+                Some('z'),
+                None,
+                None,
+                mainargs.TokensReader.StringRead,
+                positional = false,
+                hidden = false
+              )
+            ),
+            List(),
+            List(),
+            None
+          )
       }
+
       test("failedInnerOuter") {
-        TestUtils.scala2Only {
-          assertMatch(
-            barParser.constructRaw(
-              Seq("-w", "-x", "xxx", "-y", "hohoho", "-z", "xxx")
-            )
-          ) {
-            case Result.Failure.InvalidArguments(
-                  Seq(
-                    Result.ParamError.Failed(
-                      ArgSig(None, Some('x'), None, None, _, false, _),
-                      Seq("xxx"),
-                      _
-                    ),
-                    Result.ParamError.Failed(
-                      ArgSig(None, Some('y'), None, None, _, false, _),
-                      Seq("hohoho"),
-                      _
-                    )
+        assertMatch(
+          barParser.constructRaw(
+            Seq("-w", "-x", "xxx", "-y", "hohoho", "-z", "xxx")
+          )
+        ) {
+          case Result.Failure.InvalidArguments(
+                Seq(
+                  Result.ParamError.Failed(
+                    ArgSig(None, Some('x'), None, None, _, false, _),
+                    Seq("xxx"),
+                    _
+                  ),
+                  Result.ParamError.Failed(
+                    ArgSig(None, Some('y'), None, None, _, false, _),
+                    Seq("hohoho"),
+                    _
                   )
-                ) =>
-          }
+                )
+              ) =>
+
         }
       }
     }
 
     test("doubleNested") {
-      TestUtils.scala2Only {
-        quxParser.constructOrThrow(
-          Seq("-w", "-x", "1", "-y", "2", "-z", "xxx", "--moo", "cow")
-        ) ==>
-          Qux("cow", Bar(Flag(true), Foo(1, 2), "xxx"))
-      }
+      quxParser.constructOrThrow(
+        Seq("-w", "-x", "1", "-y", "2", "-z", "xxx", "--moo", "cow")
+      ) ==>
+        Qux("cow", Bar(Flag(true), Foo(1, 2), "xxx"))
     }
     test("success") {
-      TestUtils.scala2Only {
-        ParserForMethods(Main).runOrThrow(
-          Seq("-x", "1", "-y", "2", "-z", "hello")
-        ) ==> "false 1 2 hello false"
-      }
+      ParserForMethods(Main).runOrThrow(
+        Seq("-x", "1", "-y", "2", "-z", "hello")
+      ) ==> "false 1 2 hello false"
     }
   }
 }

--- a/mainargs/test/src/ClassWithDefaultTests.scala
+++ b/mainargs/test/src/ClassWithDefaultTests.scala
@@ -1,0 +1,60 @@
+package mainargs
+import utest._
+
+// Make sure
+object ClassWithDefaultTests extends TestSuite {
+  @main
+  case class Foo(x: Int, y: Int = 1)
+
+  implicit val fooParser: ParserForClass[Foo] = ParserForClass[Foo]
+
+  object Main {
+    @main
+    def run(foo: Foo, bool: Boolean = false) = s"${foo.x} ${foo.y} $bool"
+  }
+
+  val mainParser = ParserForMethods(Main)
+
+  val tests = Tests {
+    test("simple") {
+      test("success") {
+        fooParser.constructOrThrow(Seq("-x", "1", "-y", "2")) ==> Foo(1, 2)
+      }
+      test("default") {
+        fooParser.constructOrThrow(Seq("-x", "0")) ==> Foo(0, 1)
+      }
+      test("missing") {
+        fooParser.constructRaw(Seq()) ==>
+          Result.Failure.MismatchedArguments(
+            Seq(
+              ArgSig(
+                None,
+                Some('x'),
+                None,
+                None,
+                mainargs.TokensReader.IntRead,
+                positional = false,
+                hidden = false
+              )
+            ),
+            List(),
+            List(),
+            None
+          )
+
+      }
+    }
+
+    test("nested") {
+      test("success"){
+        mainParser.runOrThrow(Seq("-x", "1", "-y", "2", "--bool", "true")) ==> "1 2 true"
+      }
+      test("default"){
+        mainParser.runOrThrow(Seq("-x", "1", "-y", "2")) ==> "1 2 false"
+      }
+      test("default2"){
+        mainParser.runOrThrow(Seq("-x", "0")) ==> "0 1 false"
+      }
+    }
+  }
+}

--- a/mainargs/test/src/ParserTests.scala
+++ b/mainargs/test/src/ParserTests.scala
@@ -51,11 +51,8 @@ object ParserTests extends TestSuite {
       ) ==> Right("xxxxx")
     }
     test("constructEither") {
-      TestUtils.scala2Only {
-        // default values in classes not working on Scala 3
-        classParser.constructEither(Array("--code", "println(1)")) ==>
-          Right(ClassBase(code = Some("println(1)"), other = "hello"))
-      }
+      classParser.constructEither(Array("--code", "println(1)")) ==>
+        Right(ClassBase(code = Some("println(1)"), other = "hello"))
     }
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -519,6 +519,11 @@ command-line friendly tool.
 
 # Changelog
 
+## master
+
+- Fix handling of case class main method parameter default parameters in Scala 3
+  [#88](https://github.com/com-lihaoyi/mainargs/pull/88)
+
 ## 0.5.0
 
 - Remove hard-code support for mainargs.Leftover/Flag/Subparser to support


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mainargs/issues/33, as well as `@arg` annotations not working on `case class` arguments (which doesn't have an open issue)

Just need some special casing for `apply`/`<init>`, both for getting the `apply` defaults (which are named `<init>$default$n` since they're shared) and for getting the `apply` parameter annotations (which end up on the `<init>` method parameters, rather than the `apply` method)

Re-enabled a bunch of previously-disabled tests, and added a new suite to exercise default parameters in direct/nested scenarios