### PR TITLE
Support `--foo=bar` syntax

### DIFF
--- a/mainargs/test/src/EqualsSyntaxTests.scala
+++ b/mainargs/test/src/EqualsSyntaxTests.scala
@@ -1,0 +1,55 @@
+package mainargs
+import utest._
+
+object EqualsSyntaxTests extends TestSuite {
+
+  object Main {
+    @main
+    def run(
+        @arg(short = 'f', doc = "String to print repeatedly")
+        foo: String,
+        @arg(name = "my-num", doc = "How many times to print string")
+        myNum: Int = 2,
+        @arg(doc = "Example flag")
+        bool: Flag
+    ) = {
+      foo * myNum + " " + bool.value
+    }
+  }
+
+  val tests = Tests {
+    test("simple") {
+      ParserForMethods(Main).runOrThrow(Array("--foo=bar", "--my-num=3")) ==>
+        "barbarbar false"
+    }
+    test("multipleEquals") {
+      // --foo=bar syntax still works when there's an `=` on the right
+      ParserForMethods(Main).runOrThrow(Array("--foo=bar=qux")) ==>
+        "bar=quxbar=qux false"
+    }
+    test("shortName") {
+      // -f=bar syntax doesn't work for short names
+      ParserForMethods(Main).runEither(Array("-f=bar")) ==>
+        Left(
+          """Missing argument: -f --foo <str>
+            |Unknown argument: "-f=bar"
+            |Expected Signature: run
+            |  -f --foo <str>  String to print repeatedly
+            |  --my-num <int>  How many times to print string
+            |  --bool          Example flag
+            |
+            |""".stripMargin)
+    }
+    test("notFlags") {
+      // -f=bar syntax doesn't work for flags
+      ParserForMethods(Main).runEither(Array("--foo=bar", "--bool=true")) ==>
+         Left("""Unknown argument: "--bool=true"
+                |Expected Signature: run
+                |  -f --foo <str>  String to print repeatedly
+                |  --my-num <int>  How many times to print string
+                |  --bool          Example flag
+                |
+                |""".stripMargin)
+    }
+  }
+}

--- a/mainargs/test/src/HelloWorldTests.scala
+++ b/mainargs/test/src/HelloWorldTests.scala
@@ -42,5 +42,28 @@ object HelloWorldTests extends TestSuite {
       ParserForMethods(Main).runEither(Array("qux", "4", "--bool"), allowPositional = true) ==>
         Right("quxquxquxqux true")
     }
+
+    test("equalsSyntax") {
+      ParserForMethods(Main).runOrThrow(Array("--foo=bar", "--my-num=3")) ==>
+        "barbarbar false"
+
+      // --foo=bar syntax still works when there's an `=` on the right
+      ParserForMethods(Main).runOrThrow(Array("--foo=bar=qux")) ==>
+        "bar=quxbar=qux false"
+
+      // -f=bar syntax for short names
+      ParserForMethods(Main).runOrThrow(Array("-f=bar")) ==>
+        "barbar false"
+
+      // -f=bar syntax doesn't work for flags
+      ParserForMethods(Main).runEither(Array("-f=bar", "--bool=true")) ==>
+         Left("""Unknown argument: "--bool=true"
+                |Expected Signature: run
+                |  -f --foo <str>  String to print repeatedly
+                |  --my-num <int>  How many times to print string
+                |  --bool          Example flag
+                |
+                |""".stripMargin)
+    }
   }
 }

--- a/mainargs/test/src/HelloWorldTests.scala
+++ b/mainargs/test/src/HelloWorldTests.scala
@@ -42,28 +42,5 @@ object HelloWorldTests extends TestSuite {
       ParserForMethods(Main).runEither(Array("qux", "4", "--bool"), allowPositional = true) ==>
         Right("quxquxquxqux true")
     }
-
-    test("equalsSyntax") {
-      ParserForMethods(Main).runOrThrow(Array("--foo=bar", "--my-num=3")) ==>
-        "barbarbar false"
-
-      // --foo=bar syntax still works when there's an `=` on the right
-      ParserForMethods(Main).runOrThrow(Array("--foo=bar=qux")) ==>
-        "bar=quxbar=qux false"
-
-      // -f=bar syntax for short names
-      ParserForMethods(Main).runOrThrow(Array("-f=bar")) ==>
-        "barbar false"
-
-      // -f=bar syntax doesn't work for flags
-      ParserForMethods(Main).runEither(Array("-f=bar", "--bool=true")) ==>
-         Left("""Unknown argument: "--bool=true"
-                |Expected Signature: run
-                |  -f --foo <str>  String to print repeatedly
-                |  --my-num <int>  How many times to print string
-                |  --bool          Example flag
-                |
-                |""".stripMargin)
-    }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mainargs/issues/97

Relatively straightforward change. We do `head.split("=", 2) match` to see if it contains any `=`, and if so treat the portion of the string after the first `=` as the value. Added some unit test to cover both success cases and failure cases: use with short  names or with flags is unsupported. 