### PR TITLE
docs: make use of `info.releaseNotesURL`

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -38,7 +38,7 @@ trait MainArgsPublishModule
 
   def pomSettings = PomSettings(
     description = "Main method argument parser for Scala",
-    organization = githubOrg,
+    organization = "com.lihaoyi",
     url = projectUrl,
     licenses = Seq(License.MIT),
     versionControl = VersionControl.github(githubOrg, githubRepo),

--- a/build.sc
+++ b/build.sc
@@ -13,6 +13,11 @@ val scala3 = "3.1.3"
 val osLib = "0.9.1"
 val acyclic = "0.3.9"
 
+val githubOrg = "com-lihaoyi"
+val githubRepo = "mainargs"
+val projectUrl = s"https://github.com/${githubOrg}/${githubRepo}"
+val changelogUrl = s"${projectUrl}#changelog"
+
 val scalaVersions = List(scala212, scala213, scala3)
 
 trait MainArgsPublishModule
@@ -27,12 +32,16 @@ trait MainArgsPublishModule
 
   override def versionScheme: T[Option[VersionScheme]] = T(Some(VersionScheme.EarlySemVer))
 
+  def publishProperties = super.publishProperties() ++ Map(
+    "info.releaseNotesURL" -> changelogUrl
+  )
+
   def pomSettings = PomSettings(
     description = "Main method argument parser for Scala",
-    organization = "com.lihaoyi",
-    url = "https://github.com/com-lihaoyi/mainargs",
+    organization = githubOrg,
+    url = projectUrl,
     licenses = Seq(License.MIT),
-    versionControl = VersionControl.github("com-lihaoyi", "mainargs"),
+    versionControl = VersionControl.github(githubOrg, githubRepo),
     developers = Seq(
       Developer("lihaoyi", "Li Haoyi", "https://github.com/lihaoyi")
     )
@@ -54,7 +63,7 @@ trait MainArgsPublishModule
       )
 
   def ivyDeps = Agg(
-    ivy"org.scala-lang.modules::scala-collection-compat::2.8.1",
+    ivy"org.scala-lang.modules::scala-collection-compat::2.8.1"
   )
 }
 


### PR DESCRIPTION
This just ensures that when Scala Steward sends in a PR to your project
using mainargs that it correctly points to the changelog allowing people
to easily just click it and go directly to it.
