### PR TITLE
fix: make sure `runEither` isn't calling itself

### DIFF
--- a/mainargs/src/Parser.scala
+++ b/mainargs/src/Parser.scala
@@ -213,7 +213,8 @@ class ParserForMethods[B](val mains: MethodMains[B]) {
     autoPrintHelpAndExit,
     customNames,
     customDocs,
-    sorted
+    sorted,
+    Util.kebabCaseNameMapper
   )
   @deprecated("Binary Compatibility Shim", "mainargs 0.6.0")
   def runRaw(

--- a/mainargs/test/src/ParserTests.scala
+++ b/mainargs/test/src/ParserTests.scala
@@ -54,5 +54,8 @@ object ParserTests extends TestSuite {
       classParser.constructEither(Array("--code", "println(1)")) ==>
         Right(ClassBase(code = Some("println(1)"), other = "hello"))
     }
+    test("simplerunOrExit") {
+      singleMethodParser.runOrExit(Array("-i", "2")) ==> "lolslols"
+    }
   }
 }


### PR DESCRIPTION
It looks like this was overlooked and the overloaded `runEither` is just constantly calling itself resulting in a stack overflow. This changes it to call the newly created `runEither` with the `nameMapper` which I believe is the intended flow.

fixes #106