### PR TITLE
Make combine short args that fail to parse go through normal leftover-token code paths

### DIFF
--- a/mainargs/test/src/FlagTests.scala
+++ b/mainargs/test/src/FlagTests.scala
@@ -112,12 +112,10 @@ object FlagTests extends TestSuite {
       test - check(
         List("bool", "-ab"),
         Result.Failure.MismatchedArguments(
+          Vector(new ArgSig(None, Some('b'), None, None, TokensReader.BooleanRead, false, false)),
+          List("-ab"),
           Nil,
-          Nil,
-          Nil,
-          Some(
-            new ArgSig(None, Some('b'), None, None, TokensReader.BooleanRead, false, false)
-          )
+          None
         )
       )
 
@@ -128,7 +126,7 @@ object FlagTests extends TestSuite {
 
       test - check(
         List("str", "-bvalue", "-akey=value"),
-        Result.Failure.MismatchedArguments(Nil, List("-k"), Nil, None)
+        Result.Failure.MismatchedArguments(Nil, List("-akey=value"), Nil, None)
       )
     }
 

--- a/mainargs/test/src/PositionalTests.scala
+++ b/mainargs/test/src/PositionalTests.scala
@@ -44,7 +44,31 @@ object PositionalTests extends TestSuite {
     )
     test - check(
       List("-x", "true", "-y", "false", "-z", "false"),
-      Result.Failure.MismatchedArguments(List(), List("-y"), List(), None)
+      Result.Failure.MismatchedArguments(
+        List(
+          ArgSig(
+            None,
+            Some('y'),
+            None,
+            None,
+            TokensReader.BooleanRead,
+            positional = true,
+            hidden = false
+          ),
+          ArgSig(
+            None,
+            Some('z'),
+            None,
+            None,
+            TokensReader.BooleanRead,
+            positional = false,
+            hidden = false
+          )
+        ),
+        List("-y", "false", "-z", "false"),
+        List(),
+        None
+      )
     )
   }
 }

--- a/mainargs/test/src/VarargsBaseTests.scala
+++ b/mainargs/test/src/VarargsBaseTests.scala
@@ -113,5 +113,20 @@ trait VarargsBaseTests extends TestSuite {
             ) =>
       }
     }
+
+    test("failedCombinedShortArgsGoToLeftover"){
+      test - check(
+        List("mixedVariadic", "-f", "123", "abc", "xyz"),
+        Result.Success("123abcxyz")
+      )
+      test - check(
+        List("mixedVariadic", "-f123", "456", "abc", "xyz"),
+        Result.Success("123456abcxyz")
+      )
+      test - check(
+        List("mixedVariadic", "-f123", "-unknown", "456", "abc", "xyz"),
+        Result.Success("123-unknown456abcxyz")
+      )
+    }
   }
 }


### PR DESCRIPTION
Previously, we aggressively errored out, which prevented the normal `def complete` logic from happening: reporting missing arguments, passing remaining tokens to `Leftover`, etc. This change makes it so that we just go through the normal code paths when combined short args fail to parse, making the error reporting more consistent with the rest of MainArgs and allowing tokens such as `-foo` to be passed to `Leftover` when possible

Covered by additional unit tests