### PR TITLE
Ensure `.scalafmt.conf` is correct for Scala 3 sources

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,7 @@
 version = "3.7.3"
 
+project.git = true
+
 align.preset = none
 align.openParenCallSite = false
 align.stripMargin = true
@@ -19,3 +21,11 @@ newlines.source = keep
 
 runner.dialect = scala213
 
+fileOverride {
+  "glob:**/mainargs/src-3/**" {
+     runner.dialect = scala3
+  }
+  "glob:**/mainargs/test/src-3/**" {
+     runner.dialect = scala3
+  }
+}


### PR DESCRIPTION
This also marks `project.git` as `true` to make sure scalafmt doesn't look into any dirs that are ignored.

So it doesn't look like scalafmt is actually enforced at all in the project, but since the file exists, Metals warns when you open since it's technically incorrect for the Scala 3 sources. This just fixes that to make sure Metals users don't get a warning upon opening the project.