### PR TITLE
Fix usage of `ParserForClass` for `case class`es with more than 22 parameters with some default values in Scala 2.x

### DIFF
--- a/mainargs/src-2/Macros.scala
+++ b/mainargs/src-2/Macros.scala
@@ -96,11 +96,13 @@ class Macros(val c: Context) {
 
     val argListSymbol = q"${c.fresh[TermName](TermName("argsList"))}"
 
-    val defaults = for ((arg, i) <- flattenedArgLists.zipWithIndex) yield {
+    val defaults = for ((arg0, i) <- flattenedArgLists.zipWithIndex) yield {
       val arg = TermName(c.freshName())
-      hasDefault(i).map(defaultName =>
-        q"($arg: $curCls) => $arg.${newTermName(defaultName)}"
-      )
+      hasDefault(i) match{
+        case None => q"_root_.scala.None"
+        case Some(defaultName) =>
+          q"_root_.scala.Some[$curCls => ${arg0.info}](($arg: $curCls) => $arg.${newTermName(defaultName)}: ${arg0.info})"
+      }
     }
 
     val argSigs = for ((arg, defaultOpt) <- flattenedArgLists.zip(defaults)) yield {

--- a/mainargs/test/src/InvocationArgs.scala
+++ b/mainargs/test/src/InvocationArgs.scala
@@ -1,0 +1,50 @@
+package mainargs
+import utest._
+@main
+case class LargeArgs(
+  v1: String,
+  v2: String = "v2-default",
+  v3: Option[String] = None,
+  v4: Option[String] = None,
+  v5: Int,
+  v6: Int = 0,
+  v7: Int = 123,
+  v8: Int = 3.14.toInt,
+  v9: Boolean,
+  v10: Boolean = true,
+  v11: Boolean = false,
+  v12: Option[Int] = None,
+  v13: Option[Int] = None,
+  v14: String = "v14-default",
+  v15: String = "v15-default",
+  v16: String = "v16-default",
+  v17: String = "v17-default",
+  v18: String = "v18-default",
+  v19: String = "v19-default",
+  v20: String = "v20-default",
+  v21: String = "v21-default",
+  v22: String = "v22-default",
+  v23: String = "v23-default",
+  v24: String = "v24-default",
+  v25: String = "v25-default",
+  v26: String = "v26-default",
+  v27: String = "v27-default",
+  v28: String = "v28-default",
+  v29: String = "v29-default",
+  v30: String = "v30-default",
+  v31: String = "v31-default",
+  v32: String = "v32-default",
+)
+
+object LargeClassTests extends TestSuite{
+  val largeArgsParser = ParserForClass[LargeArgs]
+
+  val tests = Tests {
+    test("simple") {
+      largeArgsParser.constructOrThrow(
+        Seq("--v1", "v1-value", "--v5", "5", "--v9", "true", "--v23", "v23-value")
+      ) ==>
+        LargeArgs(v1 = "v1-value", v5 = 5, v9 = true, v23 = "v23-value")
+    }
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -625,6 +625,10 @@ command-line friendly tool.
 
 # Changelog
 
+## master
+
+- Fix usage of `ParserForClass` for `case class`es with more than 22 parameters in Scala 2.x
+
 ## 0.6.2
 
 - Make combine short args that fail to parse go through normal leftover-token code paths


### PR DESCRIPTION
Somehow, the type annotation in the Scala 2 macro is necessary to avoid a compiler crash for large case classes which use default values, due to some issue with type inference: the lambda we generate that wraps a call to the default parameter method gets its type inferred as `<error>` after the `uncurry` phase. 

Not sure exactly what is the cause, but providing an explicit type annotation to the return value of the lambda seems to work around the problem

PR contains a repro and unit test