### PR TITLE
Add BigDecimal TokensReader

### DIFF
--- a/mainargs/src/TokensReader.scala
+++ b/mainargs/src/TokensReader.scala
@@ -131,6 +131,10 @@ object TokensReader {
     def shortName = "double"
     def read(strs: Seq[String]) = tryEither(strs.last.toDouble)
   }
+  implicit object BigDecimalRead extends Simple[BigDecimal] {
+    def shortName = "bigdecimal"
+    def read(strs: Seq[String]) = tryEither(BigDecimal(strs.last))
+  }
 
   implicit def LeftoverRead[T: TokensReader.Simple]: TokensReader.Leftover[mainargs.Leftover[T], T] =
     new LeftoverRead[T]()(implicitly[TokensReader.Simple[T]])

--- a/mainargs/test/src/ManyTests.scala
+++ b/mainargs/test/src/ManyTests.scala
@@ -17,7 +17,7 @@ object ManyTests extends TestSuite {
       k: Int,
       l: Boolean,
       m: Double,
-      n: BigDecimal,
+      n: BigDecimal
   )
 
   val parser = ParserForClass[Config]

--- a/mainargs/test/src/ManyTests.scala
+++ b/mainargs/test/src/ManyTests.scala
@@ -15,7 +15,9 @@ object ManyTests extends TestSuite {
       i: Boolean,
       j: String,
       k: Int,
-      l: Boolean
+      l: Boolean,
+      m: Double,
+      n: BigDecimal,
   )
 
   val parser = ParserForClass[Config]
@@ -46,7 +48,11 @@ object ManyTests extends TestSuite {
           "--k",
           "4",
           "--l",
-          "false"
+          "false",
+          "--m",
+          "5.50",
+          "--n",
+          "12345678901234567890.12345678901234567890"
         ),
         allowPositional = true
       )
@@ -73,7 +79,11 @@ object ManyTests extends TestSuite {
           "--k",
           "4",
           "--l",
-          "false"
+          "false",
+          "--m",
+          "5.50",
+          "--n",
+          "12345678901234567890.12345678901234567890"
         ),
         allowPositional = true
       )
@@ -115,7 +125,9 @@ object ManyTests extends TestSuite {
           "true",
           "J",
           "4",
-          "false"
+          "false",
+          "5.50",
+          "12345678901234567890.12345678901234567890"
         ),
         allowPositional = true
       )


### PR DESCRIPTION
I was playing around with `mainargs` for a script of mine and I noticed that there were no implicit for the `BigDecimal` type. Since I think could be a quite standard type to use I thought about opening this PR also thanks to @lolgab 

Pull Request: https://github.com/com-lihaoyi/mainargs/pull/152