### PR TITLE
Fix error reporting of incomplete short args

### DIFF
--- a/mainargs/test/src/CoreTests.scala
+++ b/mainargs/test/src/CoreTests.scala
@@ -137,7 +137,8 @@ class CoreTests(allowPositional: Boolean) extends TestSuite {
               ) =>
         }
         test("incomplete") {
-
+          // Make sure both long args and short args properly report
+          // incomplete arguments as distinct from other mismatches
           test - assertMatch(check.parseInvoke(List("qux", "-s"))) {
             case Result.Failure.MismatchedArguments(
             Nil,

--- a/mainargs/test/src/CoreTests.scala
+++ b/mainargs/test/src/CoreTests.scala
@@ -15,7 +15,13 @@ object CoreBase {
       i: Int,
       @arg(doc = "Pass in a custom `s` to override it")
       s: String = "lols"
-  ) = s * i
+  )
+  = s * i
+  @main
+  def baz(
+      arg: Int,
+  ) = arg
+
   @main
   def ex() = throw MyException
 
@@ -45,6 +51,9 @@ class CoreTests(allowPositional: Boolean) extends TestSuite {
           |  Qux is a function that does stuff
           |    -i <int>
           |    -s <str>  Pass in a custom `s` to override it
+          |
+          |  baz
+          |    --arg <int>
           |
           |  ex
           |""".stripMargin
@@ -126,6 +135,25 @@ class CoreTests(allowPositional: Boolean) extends TestSuite {
                 Nil,
                 None
               ) =>
+        }
+        test("incomplete") {
+
+          test - assertMatch(check.parseInvoke(List("qux", "-s"))) {
+            case Result.Failure.MismatchedArguments(
+            Nil,
+            Nil,
+            Nil,
+            Some(_)
+            ) =>
+          }
+          test - assertMatch(check.parseInvoke(List("baz", "--arg"))) {
+            case Result.Failure.MismatchedArguments(
+            Nil,
+            Nil,
+            Nil,
+            Some(_)
+            ) =>
+          }
         }
       }
 

--- a/mainargs/test/src/CoreTests.scala
+++ b/mainargs/test/src/CoreTests.scala
@@ -48,7 +48,7 @@ class CoreTests(allowPositional: Boolean) extends TestSuite {
           |  qux
           |  Qux is a function that does stuff
           |    -i <int>
-          |    -s <str>  Pass in a custom `s` to override it
+          |    -s <str>     Pass in a custom `s` to override it
           |
           |  baz
           |    --arg <int>
@@ -63,26 +63,30 @@ class CoreTests(allowPositional: Boolean) extends TestSuite {
 
       assert(
         names ==
-          List("foo", "bar", "qux", "ex")
+          List("foo", "bar", "qux", "baz", "ex")
       )
       val evaledArgs = check.mains.value.map(_.flattenedArgSigs.map {
-        case (ArgSig(name, s, docs, None, parser, _, _), _) => (s, docs, None, parser)
+        case (ArgSig(name, s, docs, None, parser, _, _), _) => (name, s, docs, None, parser)
         case (ArgSig(name, s, docs, Some(default), parser, _, _), _) =>
-          (s, docs, Some(default(CoreBase)), parser)
+          (name, s, docs, Some(default(CoreBase)), parser)
       })
 
       assert(
         evaledArgs == List(
           List(),
-          List((Some('i'), None, None, TokensReader.IntRead)),
+          List((None, Some('i'), None, None, TokensReader.IntRead)),
           List(
-            (Some('i'), None, None, TokensReader.IntRead),
+            (None, Some('i'), None, None, TokensReader.IntRead),
             (
+              None,
               Some('s'),
               Some("Pass in a custom `s` to override it"),
               Some("lols"),
               TokensReader.StringRead
             )
+          ),
+          List(
+            (Some("arg"), None, None, None, TokensReader.IntRead),
           ),
           List()
         )

--- a/mainargs/test/src/CoreTests.scala
+++ b/mainargs/test/src/CoreTests.scala
@@ -18,9 +18,7 @@ object CoreBase {
   )
   = s * i
   @main
-  def baz(
-      arg: Int,
-  ) = arg
+  def baz(arg: Int) = arg
 
   @main
   def ex() = throw MyException

--- a/mainargs/test/src/FlagTests.scala
+++ b/mainargs/test/src/FlagTests.scala
@@ -112,10 +112,10 @@ object FlagTests extends TestSuite {
       test - check(
         List("bool", "-ab"),
         Result.Failure.MismatchedArguments(
-          Vector(new ArgSig(None, Some('b'), None, None, TokensReader.BooleanRead, false, false)),
-          List("-ab"),
           Nil,
-          None
+          Nil,
+          Nil,
+          Some(new ArgSig(None, Some('b'), None, None, TokensReader.BooleanRead, false, false))
         )
       )
 


### PR DESCRIPTION
This was accidentally broken in https://github.com/com-lihaoyi/mainargs/pull/102 and https://github.com/com-lihaoyi/mainargs/pull/112, and wasn't covered by tests. Noticed when trying to update Ammonite to the latest version of MainArgs in https://github.com/com-lihaoyi/Ammonite/pull/1549

Restored the special casing for tracking/handling incomplete arguments and added some unit test cases