### PR TITLE
add support for Scala 2 varargs in scala 3 macro

### DIFF
--- a/mainargs/src-3/Macros.scala
+++ b/mainargs/src-3/Macros.scala
@@ -72,8 +72,10 @@ object Macros {
     def unapply(using Quotes)(tpe: quotes.reflect.TypeRepr): Option[quotes.reflect.TypeRepr] = {
       import quotes.reflect.*
       tpe match {
-        case AnnotatedType(AppliedType(_, Seq(arg)), x)
+        case AnnotatedType(AppliedType(_, Seq(arg)), x) // Scala 3 repeated parameter
           if x.tpe =:= defn.RepeatedAnnot.typeRef => Some(arg)
+        case AppliedType(TypeRef(pre, "<repeated>"), Seq(arg)) // Scala 2 repeated parameter, can be read from Scala 3
+          if pre =:= defn.ScalaPackage.termRef => Some(arg)
         case _ => None
       }
     }

--- a/mainargs/test/src-3/VarargsScala2CompatTests.scala
+++ b/mainargs/test/src-3/VarargsScala2CompatTests.scala
@@ -1,0 +1,19 @@
+package mainargs
+import utest._
+
+object VarargsScala2CompatTests extends VarargsBaseTests {
+  object Base {
+
+    // (foo: scala.`<repeated>`[T]) === (foo: T*) in Scala 2 pickles (which can be read from Scala 3)
+    // in Scala 3, the equivalent is (foo: Seq[T] @repeated)
+    @main
+    def pureVariadic(nums: scala.`<repeated>`[Int]) = nums.sum
+
+    @main
+    def mixedVariadic(@arg(short = 'f') first: Int, args: scala.`<repeated>`[String]) =
+      first.toString + args.mkString
+  }
+
+  val check = new Checker(ParserForMethods(Base), allowPositional = true)
+  val isNewVarargsTests = false
+}


### PR DESCRIPTION
This would allow to extend `ScalafixModule` in Mill with scala 3, without having to override `fix` command

off this problem goes away if they republish, but it could be nice to have anyway - as other mixed 2.13 classpaths could be needed by a user